### PR TITLE
docs: refresh LAUNCH-REMAINING.md as the 100% rebrand finish-line tracker

### DIFF
--- a/LAUNCH-REMAINING.md
+++ b/LAUNCH-REMAINING.md
@@ -1,98 +1,173 @@
-# Deckle — Remaining Launch Tasks
+# Deckle — Rebrand Completion Tracker
 
-The DocuForge → Deckle rebrand is **functionally complete and live**. This file tracks the optional polish + housekeeping that still needs your dashboard access (I can't do these from the codebase). None of them block users from installing the SDKs and generating PDFs today.
+The DocuForge → Deckle rebrand is **shipped and live in production**. The product surface
+(website, docs, dashboard, API, all SDKs, CI) is already 100% Deckle. This file is the
+finish-line tracker for the remaining **external-distribution-surface** rebrand work that
+needs your dashboard access (npm OTP, Dev.to, Twitter, Render, Vercel, Cloudflare).
 
-_Last updated: 2026-05-25, after the end-to-end smoke test passed (zero-to-PDF in 4.3s, PDF URL resolves)._
-
----
-
-## 🔴 Do now (security)
-
-### Rotate the test API key ✅
-A `dk_live_` key was pasted into a chat during the smoke test and is now in that history.
-- Go to **app.getdeckle.dev/keys** → delete the key `dk_live_fa6RB…` → create a fresh one.
+_Last updated: 2026-05-29. Scope decision locked: **brand-completion only.** Product Hunt,
+branded `cdn.getdeckle.dev`, and the `df_live_` key prefix sunset are explicitly deferred —
+see "Deferred (post-100%)" at the bottom._
 
 ---
 
-## 🟡 Recommended before a public launch
+## Definition of "100% rebrand"
 
-### 1. Clerk production instance — ✅ DONE
-Migrated off the Clerk dev instance to production (primary domain `getdeckle.dev`).
-- [x] Created production instance (cloned from dev), "Primary application"
-- [x] Added the 5 Clerk DNS CNAMEs in Vercel DNS — all verified resolving to the correct `*.clerk.services` targets
-- [x] Clerk DNS verified; SSL certs issued for `clerk.`/`accounts.getdeckle.dev`
-- [x] Swapped `pk_live_`/`sk_live_` into Vercel `deckle-dashboard` env + redeployed
-- [x] Verified `app.getdeckle.dev` now serves `pk_live_` bound to `clerk.getdeckle.dev`
-- [ ] _Remaining only if you use the Clerk webhook for user sync:_ re-point it to the production instance + update `CLERK_WEBHOOK_SECRET` (skip if no webhook)
+The rebrand is complete when **every public-facing surface that mentions the product** says
+Deckle, and **no public-facing link** points users at a DocuForge URL or package. Concretely:
 
-### 2. Platform env var sweep (values still pointing at getdocuforge.dev)
-The *code* is clean (verified). The *deployed env var values* may still reference the old domain. Check and update:
+1. `npm view @docuforge/react-pdf` shows a deprecation pointing at `@getdeckle/react-pdf`.
+2. Dev.to profile bio + website link + all 10 articles are Deckle-branded end-to-end.
+3. Twitter `@getdeckle` (or chosen fallback) is claimed with a Deckle bio + pinned post.
+4. `Yoshyaes/deckle` GitHub repo's `homepageUrl` is `https://getdeckle.dev`.
+5. Render + Vercel **deployed env-var values** point at `getdeckle.dev` (the code is already
+   clean; only the values lag).
+6. Cloudflare 301 redirect rule: `getdocuforge.dev/*` → `https://getdeckle.dev/*`
+   (apex + `www`). `api.getdocuforge.dev` is **intentionally not** redirected during the
+   `df_live_` transition window.
+7. The brand-regression guard (`apps/api/src/__tests__/brand-guard.test.ts`) passes.
 
-**Render → `docuforge-api` service → Environment:**
-| Var | Set to | Notes |
-|-----|--------|-------|
-| `DASHBOARD_URL` | `https://app.getdeckle.dev` | **Also the CORS origin** (`apps/api/src/index.ts:47`). Without this, the dashboard can't call the API cross-origin. |
-| `API_BASE_URL` | `https://api.getdeckle.dev` | self-referential links |
-| `R2_PUBLIC_URL` | _(see CDN task below)_ | currently the `pub-*.r2.dev` URL — **works**, just unbranded |
-| `R2_BUCKET_NAME` | confirm matches the real bucket | `.env.example` says `deckle-pdfs`; verify the actual R2 bucket name or storage writes fail |
-| `EMAIL_FROM` | `Deckle <hello@getdeckle.dev>` | drip/transactional emails |
+---
 
-**Vercel → `deckle` and `deckle-dashboard` → Environment Variables** (check the **Production** environment filter — vars are scoped per environment):
+## 🔴 Remaining for 100% (your dashboard / accounts)
+
+### 1. Deprecate `@docuforge/react-pdf` on npm (~2 min, needs OTP)
+
+The package is still installable at v0.1.0, with a description that still markets the old
+brand and a homepage pointing at `getdocuforge.dev/docs/react-components` (verified
+2026-05-29). The unscoped `docuforge` on npm and `@docuforge/sdk` are **not yours** (the first
+is a squatter; the second 404s) — no action there.
+
+PowerShell-safe (the `<=` operator trips PowerShell):
+
+```powershell
+npm deprecate "@docuforge/react-pdf@0.1.0" "Renamed to @getdeckle/react-pdf - install @getdeckle/react-pdf instead. See https://getdeckle.dev"
+```
+
+Prompts for OTP. Verify:
+
+```powershell
+npm view @docuforge/react-pdf deprecated
+```
+
+### 2. Claim Twitter / X handle (~5 min)
+
+`@getdeckle` showed no public footprint per the audit (and is **not** the same as the
+DocuForge squatter `@docuforge` / "Anvillent"). Sign up:
+
+- **Handle:** `@getdeckle` if available; fall back to `@getdeckledev` or `@deckle_dev`
+  consistently.
+- **Bio:** `Pixel-perfect PDFs from HTML, React, or templates. Built for developers and AI agents.`
+- **Website:** `https://getdeckle.dev`
+- **Pinned post:** one-line "Deckle is live" + the docs URL.
+
+### 3. Render — env var sweep on the API service (~5 min)
+
+Service is named `docuforge-api` (internal identifier; cosmetic — don't rename). Render
+dashboard → service → Environment, update the **values** (code is already clean):
+
+| Var | Set to |
+|-----|--------|
+| `DASHBOARD_URL` | `https://app.getdeckle.dev` *(also the CORS origin)* |
+| `API_BASE_URL` | `https://api.getdeckle.dev` |
+| `EMAIL_FROM` | `Deckle <hello@getdeckle.dev>` |
+| `R2_BUCKET_NAME` | confirm matches the real R2 bucket (`.env.example` says `deckle-pdfs`) |
+
+Render restarts automatically on env change.
+
+### 4. Vercel — env var sweep on both projects (~5 min)
+
+Projects: `deckle` (marketing) and `deckle-dashboard`. **Production** environment scope on
+each:
+
 | Var | Set to |
 |-----|--------|
 | `NEXT_PUBLIC_API_URL` | `https://api.getdeckle.dev` |
 | `NEXT_PUBLIC_APP_URL` | `https://app.getdeckle.dev` |
 | `DASHBOARD_URL` | `https://app.getdeckle.dev` |
 
-After changing Vercel env vars, **redeploy** the affected project (env changes only take effect on a new build). Render restarts automatically on env change.
+**Redeploy each project after** — Vercel env changes only take effect on a new build.
 
-### 3. Cloudflare 301 redirects (preserve old inbound links)
-Old links to `getdocuforge.dev/*` (blog backlinks, search results, shared URLs) should forward to the new domain.
-- In the **getdocuforge.dev** Cloudflare zone → **Rules → Redirect Rules → Create rule**:
-  - **When**: `Hostname` `equals` `getdocuforge.dev` (add another for `www.getdocuforge.dev`)
-  - **Then**: Dynamic redirect, **301 (permanent)**, expression: `concat("https://getdeckle.dev", http.request.uri.path)`
-  - Preserve query string: on
-- Repeat/extend for the subdomains if you want `docs.`/`app.` old URLs to forward (api.getdocuforge.dev should **stay serving** during the key-transition window — see §6).
+### 5. Cloudflare 301 redirects on the `getdocuforge.dev` zone (~5 min)
 
-### 4. Deprecate the old npm package
-`@docuforge/react-pdf@0.1.0` is still installable. Point people to the new name. **PowerShell-safe** (the `<=` operator trips up PowerShell, so use an explicit version):
-```powershell
-npm deprecate "@docuforge/react-pdf@0.1.0" "Renamed to @getdeckle/react-pdf - install @getdeckle/react-pdf instead"
-```
-(Will prompt for an npm OTP.)
+Cloudflare → Rules → Redirect Rules → Create rule:
 
----
+- **When:** `Hostname equals getdocuforge.dev` (add a second rule for `www.getdocuforge.dev`).
+- **Then:** Dynamic redirect → **301 (permanent)** → expression:
+  ```
+  concat("https://getdeckle.dev", http.request.uri.path)
+  ```
+- **Preserve query string:** on.
+- ⚠️ **Do not** add `api.getdocuforge.dev` — the API still accepts `df_live_` keys during the
+  transition; redirecting it would break existing customers.
 
-## 🟢 Optional / nice-to-have
+### 6. Dev.to overhaul (~30–45 min)
 
-### 5. Branded PDF CDN (`cdn.getdeckle.dev`)
-PDFs currently serve from the R2 public URL (`https://pub-7a29…r2.dev/pdfs/…`) — **this works**, it's just not on-brand. To serve them from `cdn.getdeckle.dev`:
-- **Blocker**: R2 custom domains require the domain to be managed by **Cloudflare**, but `getdeckle.dev` currently uses **Vercel** nameservers.
-- **Cleanest fix**: move `getdeckle.dev` DNS to Cloudflare (re-point the registrar's nameservers at Cloudflare, then recreate the `api` / `app` / `docs` CNAMEs there). Then: Cloudflare R2 → bucket → Settings → Custom Domains → add `cdn.getdeckle.dev`; set Render `R2_PUBLIC_URL=https://cdn.getdeckle.dev`.
-- Until then, the `r2.dev` URLs are fine for low/moderate volume (they're rate-limited at high scale).
+The 10 published articles on `dev.to/yoshyaes` are the loudest residual DocuForge surface
+(audit: bio still says "Building DocuForge"; all 10 articles reference DocuForge in title /
+body / code samples). Strategy locked: **in-place rewrite** to preserve article URLs.
 
-### 6. Retire the `df_live_` key prefix (after a transition window)
-The API accepts **both** `df_live_` and `dk_live_` prefixes right now (`apps/api/src/middleware/auth.ts`) so existing customer keys keep working. Once your logs show no `df_live_` traffic for ~30 days:
-- Remove the `df_live_` branch from the auth middleware + the global error handler (`apps/api/src/index.ts`), and update the related test.
-- Keep `api.getdocuforge.dev` serving until then (it shares the Render service, so it already does).
+I generated the full paste-in kit in **`deckle_rebrand/devto-rewrite.md`** (gitignored;
+~5,500 lines). It contains:
 
-### 7. Repo housekeeping
-- **Helper scripts** from the rebrand (`scripts/rebrand.ps1`, `scripts/npm-rename.ps1`) — ✅ removed (preserved in git history if ever needed).
-- **Old brand assets**: `apps/web/public/brand-sheet.png` is still the DocuForge press sheet (no Deckle equivalent shipped in `deckle_rebrand/`). It's unreferenced by code (only mentioned in old audit notes), so it's harmless — regenerate a Deckle version when you build a press/brand page, or delete it. The untracked `DocuForge Assets/` folder at the repo root is your old working assets; delete from disk whenever.
-- **External profiles** (not in the repo): update Dev.to / Hashnode / GitHub / Twitter / LinkedIn / Product Hunt bios from "DocuForge" to "Deckle" — old article URLs will 301 once §3 is done.
+- Profile copy (bio + "Currently hacking on" + website) — do these first.
+- One block per article with the article ID, edit URL, new title (if applicable), a summary
+  of what was replaced, and the **full updated `body_markdown`** ready to paste.
+- 389 DocuForge-shaped tokens → 0 after rewrite, verified.
 
-### 8. Local toolchain note
-Your terminal runs **Node v20 / pnpm 9.15**, but the project declares `engines: node >=22` and `packageManager: pnpm@10.30.2`. Publishes worked anyway (just an "Unsupported engine" warning), but consider `nvm use 22` + `corepack prepare pnpm@10.30.2 --activate` to match CI and avoid edge-case build differences.
+Workflow per article: open the edit URL, replace title (if flagged), paste the body, save.
 
 ---
 
-## ✅ Done (for reference)
+## ✅ Done
 
-- All code rebranded DocuForge → Deckle (9 commits, pushed to `Yoshyaes/deckle`)
-- **SDKs published & verified live:** `@getdeckle/sdk`, `@getdeckle/react-pdf` (npm), `deckle` (PyPI), `deckle` (RubyGems), `github.com/Yoshyaes/deckle/packages/sdk-go` (Go); `v1.0.0` across the board
-- API live on `api.getdeckle.dev` (rebrand code, Redis healthy, accepts both key prefixes)
-- Marketing (`getdeckle.dev`), docs (`docs.getdeckle.dev`), dashboard (`app.getdeckle.dev`) live with SSL
-- GitHub repo renamed `docuforge` → `deckle`; local remote updated
-- Brand assets swapped (favicons, icons, logos, OG image)
-- **End-to-end smoke test passed**: signup → `npm install @getdeckle/sdk @getdeckle/react-pdf` → `dk.generate({ html })` → working PDF, **4.3s** zero-to-PDF, returned URL resolves (HTTP 200, application/pdf)
-- Backup branch `backup-pre-rebrand` pins the pre-rebrand state
+- **Code rebrand fully shipped:** apps, all 4 SDKs (`@getdeckle/sdk`, `@getdeckle/react-pdf`,
+  `deckle` on PyPI verified 2026-05-29, `deckle` on RubyGems, Go module path), MCP server
+  with full 17-tool PDF lifecycle.
+- **Clerk production instance** migrated off dev; `pk_live_`/`sk_live_` swapped into Vercel.
+- **Brand-regression guard test** (`apps/api/src/__tests__/brand-guard.test.ts`) passes —
+  no `docuforge` (any case) in tracked shipping files outside the allowlist.
+- **GitHub repo native rename:** `Yoshyaes/docuforge` is a native redirect to
+  `Yoshyaes/deckle` (verified via identical `gh repo view` output) — the audit's claim of a
+  "parallel repo" was a fetcher artifact; no action needed.
+- **GitHub `homepageUrl`** updated to `https://getdeckle.dev` (was `docuforge-eta.vercel.app`).
+- **Sign-in CSP fix** — added `clerk.getdeckle.dev` to the dashboard CSP allowlist after the
+  dev → prod Clerk migration; verified live (PR #11).
+- **CI rot fix** — pnpm-setup config, Node 20 → 22 (for `isolated-vm`), Go 1.21 → 1.22,
+  plus pre-existing test type errors. CI is fully green on master (PR #12).
+- **Test API key rotation** done after the early smoke-test leak.
+- **End-to-end smoke test:** signup → `npm install @getdeckle/sdk @getdeckle/react-pdf` →
+  `dk.generate({ html })` → working PDF in **4.3s**.
+
+---
+
+## 🟢 Deferred (post-100%)
+
+These are intentionally out of "100% rebrand" scope — they're launch milestones, multi-step
+migrations, or time-gated tasks, each worth its own plan.
+
+- **`apps/web/public/brand-sheet.png`** — 195KB stale DocuForge press sheet, unreferenced by
+  any shipping code (only audit notes mention it). Delete or replace whenever; harmless until
+  then.
+- **`DocuForge Assets/`** folder at the repo root — gitignored, untracked. Delete from disk
+  whenever.
+- **Product Hunt launch** under the Deckle name. No listing exists under either brand.
+- **Branded CDN** `cdn.getdeckle.dev` — blocked on moving `getdeckle.dev` DNS from Vercel to
+  Cloudflare (needed for R2 custom domains). R2 `pub-*.r2.dev` URLs work fine in the
+  meantime.
+- **`df_live_` key prefix sunset** — `apps/api/src/middleware/auth.ts` accepts both prefixes.
+  Wait until logs show 30 days of zero `df_live_` traffic (~26 days from today).
+  Then remove the `df_live_` branch + the related test, and decommission
+  `api.getdocuforge.dev`.
+- **Render service rename** `docuforge-api` → `deckle-api` — internal identifier only.
+- **Hashnode / LinkedIn / company press kit** — not in the audit's required set.
+- **Local toolchain** — your shell runs Node 20 / pnpm 9.15, project declares `engines:
+  node >=22` and `packageManager: pnpm@10.30.2`. Publishes still work (just a warning);
+  `nvm use 22` + `corepack prepare pnpm@10.30.2 --activate` to match CI.
+
+---
+
+## Rollback
+
+Pre-rebrand state is pinned at branch **`backup-pre-rebrand`** and in history-backup bundles
+under `~/deckle-history-backup-*` / `~/docuforge-history-backup-*`.


### PR DESCRIPTION
## What changed
Rewrites `LAUNCH-REMAINING.md` to be the **single source of truth** for the brand-completion finish line, reflecting today's verified state instead of the 2026-05-25 snapshot.

## Phase A deliverables that produced this
- ✅ **A.1** GitHub repo `homepageUrl` updated to `https://getdeckle.dev` (was `docuforge-eta.vercel.app`) via `gh repo edit`.
- ✅ **A.2** Brand-regression guard test passes (no `docuforge` in tracked shipping files).
- ✅ **A.3** Discovery: `@docuforge/sdk` is a **404** on npm; only `@docuforge/react-pdf` needs deprecation.
- ✅ **A.4** No `docuforge-eta.vercel.app` or `getdocuforge.dev` leaks in tracked shipping files. `brand-sheet.png` (195KB DocuForge press sheet) is unreferenced by shipping code — flagged for deletion in 'Deferred'.
- ✅ **A.5** `deckle_rebrand/devto-rewrite.md` (gitignored, ~5,500 lines): the per-article paste-in kit for all 10 Dev.to articles. **389 DocuForge-shaped tokens → 0** after rewrite, verified.
- ✅ **A.6** This commit: refreshed tracker.

## What's left for 100%
Six concrete user actions, each with copy-paste-ready commands in the tracker:
1. `npm deprecate @docuforge/react-pdf@0.1.0 ...` (needs OTP).
2. Claim Twitter/X handle.
3. Render env-var sweep on the API service.
4. Vercel env-var sweep on `deckle` + `deckle-dashboard` (Production) + redeploy.
5. Cloudflare 301 redirects on the `getdocuforge.dev` zone (apex + www; **not** `api.`).
6. Dev.to in-place rewrite using the kit at `deckle_rebrand/devto-rewrite.md`.

## Notable correction to the audit
The audit at `deckle_rebrand/reband-status.md` claimed `Yoshyaes/docuforge` was a separate parallel repo. Verified: it's actually a GitHub native rename redirect to `Yoshyaes/deckle` (`gh repo view` returns identical metadata for both). **No action needed there.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)